### PR TITLE
feat: 楽天ペイ「注文受付（自動配信メール）」対応 (#8)

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -59,6 +59,12 @@ const MAIL_FILTERS = [
     source: '楽天ペイ(オンライン)',
   },
   {
+    from: 'order@checkout.rakuten.co.jp',
+    subject: '楽天ペイ 注文受付',
+    parser: 'rakutenPayOnline',
+    source: '楽天ペイ(オンライン)',
+  },
+  {
     from: 'info@mail.rakuten-card.co.jp',
     subject: 'カード利用のお知らせ',
     parser: 'rakutenCard',

--- a/Parsers.js
+++ b/Parsers.js
@@ -53,23 +53,34 @@ const Parsers = {
   rakutenPayOnline(body) {
     const text = stripHtml_(body);
 
-    const shopMatch = text.match(/提携サイト「([^」]+)」/);
-    const dateMatch = text.match(/ご注文日[：:]\s*(\d{4}[-\/]\d{1,2}[-\/]\d{1,2})/);
+    // ショップ名: 「提携サイト「...」」または「ショップ名 ： ...」
+    const shopMatch = text.match(/提携サイト「([^」]+)」/) || text.match(/ショップ名\s*[：:]\s*([^\r\n]+)/);
+    const shop = shopMatch ? (shopMatch[1] || shopMatch[2]).trim() : null;
 
-    const shop = shopMatch ? shopMatch[1].trim() : null;
+    // 日付: 「ご注文日： ...」「注文日時： ...」「[日時] ...」など
+    const dateMatch = text.match(/(?:ご注文日|注文日時|利用日時)[：:]\s*(\d{4}[-\/]\d{1,2}[-\/]\d{1,2})/) ||
+                    text.match(/\[日時\]\s*(\d{4}[-\/]\d{1,2}[-\/]\d{1,2})/);
     const date = dateMatch
       ? dateMatch[1].replace(/\//g, '-')
       : null;
 
-    // お支払い金額 → 注文合計 → 明細合計の順で取得
+    // お支払い金額 → 注文合計 → 合計 → 明細合計の順で取得
     let amount = null;
-    const payAmountMatch = text.match(/お支払い金額[：:]\s*([\d,]+)円/);
-    const totalAmountMatch = text.match(/注文合計\s*([\d,]+)円/);
-    if (payAmountMatch) {
-      amount = parseInt(payAmountMatch[1].replace(/,/g, ''), 10);
-    } else if (totalAmountMatch) {
-      amount = parseInt(totalAmountMatch[1].replace(/,/g, ''), 10);
-    } else {
+    const amountPatterns = [
+      /お支払い金額[：:]\s*([\d,]+)円/,
+      /注文合計\s*([\d,]+)円/,
+      /合計\s*([\d,]+)円/
+    ];
+
+    for (const pattern of amountPatterns) {
+      const match = text.match(pattern);
+      if (match) {
+        amount = parseInt(match[1].replace(/,/g, ''), 10);
+        break;
+      }
+    }
+
+    if (!amount) {
       // 明細行の「＝ X,XXX円」を合計（例: 2,000円 × 1個 ＝ 2,000円）
       const lineMatches = text.match(/＝\s*([\d,]+)円/g);
       if (lineMatches) {

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -281,6 +281,7 @@ function getCategory(shopName) {
 | -------- | ---------------------------------- | -------- |
 | 楽天ペイ（アプリ） | `from:rakutengroup@mail.rakuten.com subject:楽天ペイアプリご利用内容` | `Parsers.rakutenPay()` |
 | 楽天ペイ（オンライン） | `from:payment@checkout.rakuten.co.jp subject:楽天ペイ（オンライン決済）` | `Parsers.rakutenPayOnline()` |
+| 楽天ペイ（注文受付） | `from:order@checkout.rakuten.co.jp subject:楽天ペイ 注文受付` | `Parsers.rakutenPayOnline()` |
 | 楽天カード | `from:info@mail.rakuten-card.co.jp subject:楽天カード利用のお知らせ` | `Parsers.rakutenCard()` |
 
 ## 7. セキュリティ設計


### PR DESCRIPTION
## 概要
order@checkout.rakuten.co.jp から届く「楽天ペイ 注文受付（自動配信メール）」が現在のフィルタにヒットせず、家計簿に取り込めていない問題を解消しました。

## 変更内容
- **Config.js**: 楽天ペイ（注文受付）のフィルタを `MAIL_FILTERS` に追加しました。
- **Parsers.js**: `rakutenPayOnline` パーサーを強化し、注文受付メール特有のショップ名・日付・金額の形式に対応させました。
- **docs/DESIGN.md**: フィルタ設定表を最新の状態に更新しました。

## 動作確認
- スクラッチテストを実行し、従来のオンライン決済形式と新しい注文受付形式の両方で正しくパースできることを確認済みです。
- Google Apps Script への `clasp push` も完了し、実際に保留されていたメールが取り込まれることを確認済みです。

Close #8
